### PR TITLE
Adds a bottom bar with an additional top videos tab

### DIFF
--- a/lib/src/application.dart
+++ b/lib/src/application.dart
@@ -11,7 +11,7 @@ class FlitchApp extends MaterialApp {
       : super(
           debugShowCheckedModeBanner: false,
           title: 'Flitch',
-          home: const HomeView(),
+          home: const HomeWidget(),
           theme: _twitchTheme,
         );
 }

--- a/lib/src/views/home.dart
+++ b/lib/src/views/home.dart
@@ -2,20 +2,81 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:flitch/src/widgets/top_videos.dart';
 import 'package:flutter/material.dart';
-
+import '../services.dart' as services;
 import '../widgets/game.dart';
 
-class HomeView extends StatelessWidget {
-  const HomeView();
+class HomeWidget extends StatefulWidget {
+  const HomeWidget();
 
   @override
-  Widget build(_) {
-    return new Scaffold(
-      appBar: new AppBar(
-        title: new Text('Flitch'),
-      ),
-      body: new GameList(),
-    );
+  State<StatefulWidget> createState() {
+    return new HomeWidgetState();
   }
+}
+
+class HomeWidgetState extends State<HomeWidget> {
+  int _currentIndex = 0;
+  final List<Screen> _screens = [
+    new Screen(
+      title: 'Top Games',
+      body: new TopGameList(),
+      key: new Key('TopGamesList'),
+      icon: Icons.games,
+    ),
+    new Screen(
+      title: 'Top Videos',
+      body: new TopVideosList(services.twitch),
+      key: new Key('TopVideosList'),
+      icon: Icons.videocam,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final transitionDuration = new Duration(milliseconds: 200);
+
+    return new Scaffold(
+        appBar: new AppBar(
+          title: new Text('Flitch'),
+        ),
+        body: new Stack(
+            children: (_screens
+                // Get all inactive screens
+                .where((screen) => _screens.indexOf(screen) != _currentIndex)
+                // Place them on the bottom of the Stack, and fade em out
+                .map((screen) => new AnimatedOpacity(
+                    opacity: 0.0,
+                    duration: transitionDuration,
+                    child: screen.body,
+                    key: screen.key))
+                .toList()
+                  // Finally, place the active screen on top so it can receive touch events and fade it in
+                  ..add(new AnimatedOpacity(
+                      opacity: 1.0,
+                      duration: transitionDuration,
+                      child: _screens[_currentIndex].body,
+                      key: _screens[_currentIndex].key)))),
+        bottomNavigationBar: new BottomNavigationBar(
+            currentIndex: _currentIndex,
+            onTap: (currentIndex) {
+              setState(() {
+                _currentIndex = currentIndex;
+              });
+            },
+            items: _screens
+                .map((item) => new BottomNavigationBarItem(
+                    icon: new Icon(item.icon), title: new Text(item.title)))
+                .toList()));
+  }
+}
+
+class Screen {
+  final Widget body;
+  final IconData icon;
+  final String title;
+  final Key key;
+
+  Screen({this.body, this.icon, this.title, this.key});
 }

--- a/lib/src/widgets/top_videos.dart
+++ b/lib/src/widgets/top_videos.dart
@@ -5,17 +5,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
-import '../services.dart' as services;
 import 'package:twitch/twitch.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-class TopGameList extends StatelessWidget {
-  const TopGameList();
+class TopVideosList extends StatelessWidget {
+  final Twitch twitch;
+
+  const TopVideosList(this.twitch);
 
   @override
   Widget build(BuildContext context) {
     final Orientation orientation = MediaQuery.of(context).orientation;
-    return new FutureBuilder<Response<TopGame>>(
-      future: services.twitch.getTopGames(),
+    return new FutureBuilder<Response<Video>>(
+      future: twitch.getTopVideos(),
       builder: (context, snapshot) {
         return new GridView.count(
             crossAxisCount: (orientation == Orientation.portrait) ? 2 : 3,
@@ -24,29 +26,33 @@ class TopGameList extends StatelessWidget {
             padding: const EdgeInsets.all(4.0),
             childAspectRatio: (orientation == Orientation.portrait) ? 1.0 : 1.3,
             children: snapshot != null && snapshot.data != null
-                ? snapshot.data
-                    .map((topGame) => new _GameItem(topGame))
-                    .toList()
+                ? snapshot.data.map((video) => new _VideoItem(video)).toList()
                 : []);
       },
     );
   }
 }
 
-class _GameItem extends StatelessWidget {
-  final TopGame _topGame;
+class _VideoItem extends StatelessWidget {
+  final Video _video;
 
-  const _GameItem(this._topGame);
+  const _VideoItem(this._video);
 
   @override
   Widget build(_) {
     return new GridTile(
       child: new Hero(
-        tag: _topGame.game.name,
-        child: new Image.network(
-          _topGame.game.box.large,
-          fit: BoxFit.cover,
-        ),
+        tag: _video.id,
+        child: new InkWell(
+            onTap: () async {
+              if (await canLaunch(_video.url)) {
+                await launch(_video.url);
+              }
+            },
+            child: new Image.network(
+              _video.preview.large,
+              fit: BoxFit.cover,
+            )),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,7 @@ description: A Flutter demo using the Twitch API.
 dependencies:
   flutter:
     sdk: flutter
-  twitch:
-    path: ../../lab/twitch.dart
+  twitch: 0.3.1
   url_launcher: "^0.4.2+1"
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,9 @@ description: A Flutter demo using the Twitch API.
 dependencies:
   flutter:
     sdk: flutter
-  twitch: ^0.3.0
+  twitch:
+    path: ../../lab/twitch.dart
+  url_launcher: "^0.4.2+1"
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
I've added the "Top Videos" feature to the app! 

Tech-wise: Began with a `Screen` "value" class that contains a few basic properties -- a title, body, etc. I then define a list of Screens (thus far only 2, could be more!) and use that list to create the bottom tabs and fade in the proper active `Screen` when it is selected.

A gif is worth a thousand words:

![demo](https://cloud.githubusercontent.com/assets/126604/26757319/5aa9353c-48b8-11e7-988e-4de8031d27d0.gif)
